### PR TITLE
Update Readme: use the correct grammatical case for the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ logic.
     msgid "user"
     msgstr "użytkownik"
 
-    msgctxt "nominative"
+    msgctxt "accusative"
     msgid "user"
     msgstr "użytkownika"
 
     msgid "Select {} to change"
-    msgstr "Wybierz {.nominative} do zmiany"
+    msgstr "Wybierz {.accusative} do zmiany"
     
 Second class, ``NoContextFallbackTranslations`` in case of lacking context
 translation makes gettext fall back to translation of message without context.
-In example above if ``msgstr`` for ``user/nominative`` would be empty, it would
- prefer ``"użytkownik"`` over not translated ``user/nominative`` ``"user"``.
+In example above if ``msgstr`` for ``user/accusative`` would be empty, it would
+ prefer ``"użytkownik"`` over not translated ``user/accusative`` ``"user"``.
 
 #### Example installation
 
@@ -49,19 +49,19 @@ With translation file:
     msgid "user"
     msgstr "użytkownik"
 
-    msgctxt "nominative"
+    msgctxt "accusative"
     msgid "user"
     msgstr "użytkownika"
 
     msgid "group"
     msgstr "grupa"
 
-    msgctxt "nominative"
+    msgctxt "accusative"
     msgid "group"
     msgstr "grupę"
 
     msgid "Select {} to change"
-    msgstr "Wybierz {.nominative} do zmiany"
+    msgstr "Wybierz {.accusative} do zmiany"
 
 Will produce:
     

--- a/messages.po
+++ b/messages.po
@@ -22,7 +22,7 @@ msgid "user"
 msgstr "użytkownik"
 
 #: sample_application.py:13
-msgctxt "nominative"
+msgctxt "accusative"
 msgid "user"
 msgstr "użytkownika"
 
@@ -31,10 +31,10 @@ msgid "group"
 msgstr "grupa"
 
 #: sample_application.py:16
-msgctxt "nominative"
+msgctxt "accusative"
 msgid "group"
 msgstr "grupę"
 
 #: sample_application.py:21
 msgid "Select {} to change"
-msgstr "Wybierz {.nominative} to change"
+msgstr "Wybierz {.accusative} to change"

--- a/sample_application.py
+++ b/sample_application.py
@@ -10,10 +10,10 @@ pl.install(('pgettext',))
 
 
 user = _('user')
-pgettext('nominative', 'user')  # noop
+pgettext('accusative', 'user')  # noop
 
 group = _('group')
-pgettext('nominative', 'group')  # noop
+pgettext('accusative', 'group')  # noop
 
 list = []
 


### PR DESCRIPTION
The examples use accusative ("wybierz użytkownika"). I suggest correcting the readme. It was very confusing what actually this library does. For me :)